### PR TITLE
fix php8 issue

### DIFF
--- a/modules/backup/provider/ftp.php
+++ b/modules/backup/provider/ftp.php
@@ -42,7 +42,7 @@ class FtpBackup implements IProvider
             case "Windows_NT" :
                 $split = preg_split("[ ]", $current, 9, PREG_SPLIT_NO_EMPTY);
                 if ($split[0] != "total") {
-                    if ($split[0]{0} === "d") continue 2;
+                    if ($split[0][0] === "d") continue 2;
                     if (!strpos($split[3],$pattern)) continue 2;
                     $file = array();
                     $file["NAME"] = $split[3];
@@ -65,7 +65,7 @@ class FtpBackup implements IProvider
             default:
                 $split = preg_split("[ ]", $current, 9, PREG_SPLIT_NO_EMPTY);
                 if ($split[0] != "total") {
-                    if ($split[0]{0} === "d") continue 2;
+                    if ($split[0][0] === "d") continue 2;
                     if (!strpos($split[8],$pattern)) continue 2;
                     $file = array();
                     $file["NAME"] = $split[8];


### PR DESCRIPTION
Array and string offset access syntax with curly braces is no longer supported in /var/www/html/modules/backup/provider/ftp.php on line 45